### PR TITLE
add admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# .env.example
+
+JWT_SECRET=your_jwt_secret_here
+NODE_ENV=development
+PORT=1234
+
+DB_HOST=your_db_host
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_NAME=your_db_name

--- a/app.js
+++ b/app.js
@@ -1,17 +1,29 @@
 import express, { json } from 'express'
+import cookieParser from "cookie-parser";
+import jwt from 'jsonwebtoken'
 import { createUserRouter, } from './routes/users.js'
 import { createAttributeRouter } from './routes/attributes.js'
+import { createAdminRouter } from './routes/admin.js'
 import { corsMiddleware } from './middlewares/cors.js'
+import { authenticateAdmin } from './middlewares/authenticateAdmin.js'
 
-export const createApp = ({ userModel, attributeModel }) => {
+export const createApp = ({ userModel, attributeModel, adminModel }) => {
   const app = express()
   app.use(json())
+
   app.use(corsMiddleware())
+
+  app.use(cookieParser())
+
   app.disable('x-powered-by')
+
+  app.use(authenticateAdmin)
 
   app.use('/users', createUserRouter({ userModel: userModel }))
 
   app.use('/attributes', createAttributeRouter({ attributeModel: attributeModel }))
+
+  app.use('/admin', createAdminRouter({ adminModel: adminModel }))
 
   const PORT = process.env.PORT ?? 1234
 

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -14,7 +14,7 @@ export class AdminController {
             const newAdmin = await this.adminModel.createAdmin({ input: result.data });
             res.status(201).json(newAdmin);
         } catch (error) {
-            console.error('Error creating attribute:', error);
+            console.error('Error creating admin:', error);
         }
     }
     deleteAdmin = async (req, res) => {

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -1,0 +1,92 @@
+import { validateAdmin, validatePartialAdmin, validateAdminLogin } from "../schemas/admin.js";
+
+export class AdminController {
+    constructor({ adminModel }) {
+        this.adminModel = adminModel
+    }
+    createAdmin = async (req, res) => {
+        const result = validateAdmin(req.body);
+
+        if (!result.success) {
+            return res.status(400).json({ error: JSON.parse(result.error.message) });
+        }
+        try {
+            const newAdmin = await this.adminModel.createAdmin({ input: result.data });
+            res.status(201).json(newAdmin);
+        } catch (error) {
+            console.error('Error creating attribute:', error);
+        }
+    }
+    deleteAdmin = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
+        const { id } = req.params
+        const result = await this.adminModel.deleteAdmin({ id })
+
+        if (result === false) {
+            return res.status(404).json({ message: 'Admin not found' })
+        }
+
+        return res.json({ message: 'Admin deleted' })
+    }
+
+    updateAdmin = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
+        const result = validatePartialAdmin(req.body)
+
+        if (!result.success) {
+            return res.status(400).json({ error: JSON.parse(result.error.message) })
+        }
+
+        const { id } = req.params
+        const updatedAdmin = await this.adminModel.updateAdmin({ id, input: result.data })
+
+        return res.json(updatedAdmin)
+    }
+    getAllAdmins = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
+        const { admin } = req.query
+        const admins = await this.adminModel.getAllAdmins({ admin })
+        res.json(admins)
+    }
+    getAdminById = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
+        const { id } = req.params
+        const user = await this.adminModel.getAdminById({ id })
+        if (user) return res.json(user)
+        res.status(404).json({ message: 'User not found' })
+    }
+    login = async (req, res) => {
+        const result = validateAdminLogin(req.body);
+
+        if (!result.success) {
+            return res.status(400).json({ error: JSON.parse(result.error.message) })
+        }
+        const { username, password } = req.body;
+
+        try {
+            const { token, admin } = await this.adminModel.login({ username, password });
+            res.cookie('access_token', token, {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'Strict',
+                maxAge: 7 * 24 * 60 * 60 * 1000,
+            });
+            res.status(200).json({ token, admin });
+        } catch (error) {
+            res.status(401).json({ error: 'Invalid username or password' });
+        }
+    }
+    logout = async (req, res) => {
+        res.clearCookie('access_token');
+        req.session.admin = null;
+        res.status(200).json({ message: 'Logged out successfully' });
+    }
+}

--- a/controllers/attributes.js
+++ b/controllers/attributes.js
@@ -1,4 +1,4 @@
-import { validateAttribute } from '../schemas/attribute.js'
+import { validateAttribute, validateAttributeArray, validateSingleAttribute, } from '../schemas/attribute.js'
 
 export class AttributeController {
     constructor({ attributeModel }) {
@@ -9,7 +9,7 @@ export class AttributeController {
             return res.status(401).json({ error: 'Unauthorized' });
         }
         const result = validateAttribute(req.body);
-
+        
         if (!result.success) {
             return res.status(400).json({ error: JSON.parse(result.error.message) });
         }
@@ -39,14 +39,13 @@ export class AttributeController {
         if (!req.session.admin) {
             return res.status(401).json({ error: 'Unauthorized' });
         }
-        const result = validateAttribute(req.body)
+        const atrributes = req.body?.values?.attributes
+        const result = validateAttributeArray(atrributes)
 
         if (!result.success) {
             return res.status(400).json({ error: JSON.parse(result.error.message) })
         }
-
-        const { id } = req.params
-        const updatedAttribute = await this.attributeModel.updateAttribute({ id, input: result.data })
+        const updatedAttribute = await this.attributeModel.updateAttribute({ input: result.data })
 
         return res.json(updatedAttribute)
     }

--- a/controllers/attributes.js
+++ b/controllers/attributes.js
@@ -5,6 +5,9 @@ export class AttributeController {
         this.attributeModel = attributeModel
     }
     createAttribute = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
         const result = validateAttribute(req.body);
 
         if (!result.success) {
@@ -19,6 +22,9 @@ export class AttributeController {
         }
     }
     deleteAttribute = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
         const { id } = req.params
         const result = await this.attributeModel.deleteAttribute({ id })
 
@@ -30,6 +36,9 @@ export class AttributeController {
     }
 
     updateAttribute = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
         const result = validateAttribute(req.body)
 
         if (!result.success) {
@@ -42,6 +51,9 @@ export class AttributeController {
         return res.json(updatedAttribute)
     }
     getAllAttributes = async (req, res) => {
+        if (!req.session.admin) {
+            return res.status(401).json({ error: 'Unauthorized' });
+        }
         const { attribute } = req.query
         const attributes = await this.attributeModel.getAllAttributes({ attribute })
         res.json(attributes)

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -6,12 +6,18 @@ export class UserController {
   }
 
   getAllUsers = async (req, res) => {
+    if (!req.session.admin) {
+      return res.status(401).json({ error: 'Unauthorized' });
+  }
     const { user } = req.query
     const users = await this.userModel.getAllUsers({ user })
     res.json(users)
   }
 
   getUserById = async (req, res) => {
+    if (!req.session.admin) {
+      return res.status(401).json({ error: 'Unauthorized' });
+  }
     const { id } = req.params
     const user = await this.userModel.getUserById({ id })
     if (user) return res.json(user)
@@ -19,6 +25,9 @@ export class UserController {
   }
 
   createUser = async (req, res) => {
+    if (!req.session.admin) {
+      return res.status(401).json({ error: 'Unauthorized' });
+  }
     const result = validateUser(req.body)
 
     if (!result.success) {
@@ -31,6 +40,9 @@ export class UserController {
   }
 
   deleteUser = async (req, res) => {
+    if (!req.session.admin) {
+      return res.status(401).json({ error: 'Unauthorized' });
+  }
     const { id } = req.params
     const result = await this.userModel.deleteUser({ id })
 
@@ -42,6 +54,9 @@ export class UserController {
   }
 
   updateUser = async (req, res) => {
+    if (!req.session.admin) {
+      return res.status(401).json({ error: 'Unauthorized' });
+  }
     const result = validatePartialUser(req.body)
 
     if (!result.success) {

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -1,14 +1,14 @@
 import { validateUser, validatePartialUser } from '../schemas/user.js'
 
 export class UserController {
-  constructor ({ userModel }) {
+  constructor({ userModel }) {
     this.userModel = userModel
   }
 
   getAllUsers = async (req, res) => {
     if (!req.session.admin) {
       return res.status(401).json({ error: 'Unauthorized' });
-  }
+    }
     const { user } = req.query
     const users = await this.userModel.getAllUsers({ user })
     res.json(users)
@@ -17,7 +17,7 @@ export class UserController {
   getUserById = async (req, res) => {
     if (!req.session.admin) {
       return res.status(401).json({ error: 'Unauthorized' });
-  }
+    }
     const { id } = req.params
     const user = await this.userModel.getUserById({ id })
     if (user) return res.json(user)
@@ -27,22 +27,24 @@ export class UserController {
   createUser = async (req, res) => {
     if (!req.session.admin) {
       return res.status(401).json({ error: 'Unauthorized' });
-  }
+    }
     const result = validateUser(req.body)
 
     if (!result.success) {
       return res.status(400).json({ error: JSON.parse(result.error.message) })
     }
-
-    const newUser = await this.userModel.createUser({ input: result.data })
-
-    res.status(201).json(newUser)
+    try {
+      const newUser = await this.userModel.createUser({ input: result.data })
+      res.status(201).json(newUser)
+    } catch (error) {
+      throw new Error("fail user erro:", error) 
+    }
   }
 
   deleteUser = async (req, res) => {
     if (!req.session.admin) {
       return res.status(401).json({ error: 'Unauthorized' });
-  }
+    }
     const { id } = req.params
     const result = await this.userModel.deleteUser({ id })
 
@@ -56,7 +58,7 @@ export class UserController {
   updateUser = async (req, res) => {
     if (!req.session.admin) {
       return res.status(401).json({ error: 'Unauthorized' });
-  }
+    }
     const result = validatePartialUser(req.body)
 
     if (!result.success) {

--- a/middlewares/apicache.js
+++ b/middlewares/apicache.js
@@ -1,0 +1,6 @@
+import apicache from 'apicache'
+
+let cache = apicache.middleware
+
+export const cacheFor = (duration = "5 minutos") =>(cache(duration))
+

--- a/middlewares/authenticateAdmin.js
+++ b/middlewares/authenticateAdmin.js
@@ -1,0 +1,13 @@
+
+import jwt from 'jsonwebtoken';
+
+export const authenticateAdmin = (req, res, next) => {
+    const token = req.cookies?.access_token;
+    req.session = { admin: null };
+    try {
+        const data = jwt.verify(token, process.env.JWT_SECRET);
+        req.session.admin = data;
+    } catch { }
+
+    next();
+};

--- a/middlewares/cors.js
+++ b/middlewares/cors.js
@@ -3,6 +3,7 @@ import cors from 'cors'
 const ACCEPTED_ORIGINS = [
   'http://localhost:8080',
   'http://localhost:1234',
+  'http://localhost:3000',
 ]
 
 export const corsMiddleware = ({ acceptedOrigins = ACCEPTED_ORIGINS } = {}) => cors({
@@ -16,5 +17,6 @@ export const corsMiddleware = ({ acceptedOrigins = ACCEPTED_ORIGINS } = {}) => c
     }
 
     return callback(new Error('Not allowed by CORS'))
-  }
+  },
+  credentials: true
 })

--- a/models/mysql/admin.js
+++ b/models/mysql/admin.js
@@ -5,14 +5,12 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const secretKey = process.env.JWT_SECRET;
-
-const config = {
-    host: "localhost",
-    user: "root",
-    password: "",
-    database: "usersdb"
-}
-
+const config= {
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  };
 const connection = await mysql.createConnection(config)
 console.log("Connected to MySQL database")
 

--- a/models/mysql/admin.js
+++ b/models/mysql/admin.js
@@ -1,0 +1,117 @@
+import mysql from "mysql2/promise";
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const secretKey = process.env.JWT_SECRET;
+
+const config = {
+    host: "localhost",
+    user: "root",
+    password: "",
+    database: "usersdb"
+}
+
+const connection = await mysql.createConnection(config)
+console.log("Connected to MySQL database")
+
+export class AdminModel {
+    static async getAllAdmins() {
+        const [rows] = await connection.query(`SELECT BIN_TO_UUID(id) id, username, email, full_name, password
+      FROM admin;`)
+        return rows
+    }
+
+    static async createAdmin({ input }) {
+        const {
+            full_name,
+            email,
+            username,
+            password,
+        } = input;
+        // 1. Validar que el username no exista
+        const [validUserName] = await connection.query(
+            'SELECT * FROM admin WHERE userName = ?',
+            [username]
+        );
+        if (validUserName.length > 0) {
+            throw new Error('Username already exists');
+        }
+        try {
+            const [uuidResult] = await connection.query('SELECT UUID() uuid;');
+            const [{ uuid }] = uuidResult;
+
+            const passwordHash = await bcrypt.hash(password, 10);
+            await connection.query(
+                `INSERT INTO admin (id, username, email, full_name, password)
+        VALUES (UUID_TO_BIN(?), ?, ?, ?, ?);`,
+                [uuid, username, email, full_name, passwordHash]
+            );
+
+            const [adminsResult] = await connection.query(
+                `SELECT BIN_TO_UUID(id) id, userName, email, full_name
+         FROM admin WHERE id = UUID_TO_BIN(?)`,
+                [uuid]
+            );
+
+            return adminsResult[0];
+        } catch (e) {
+            throw new Error('Error creating admin');
+        }
+    }
+
+    static async updateAdmin({ id, input }) {
+        const allowedFields = ['username', 'email', 'full_name', 'password'];
+        const fields = Object.keys(input).filter(field => allowedFields.includes(field));
+
+        if (fields.length === 0) {
+            throw new Error('No fields to update');
+        }
+
+        if (input.password) {
+            const hashedPassword = await bcrypt.hash(input.password, 10);
+            input.password = hashedPassword;
+        }
+        const setClause = fields.map(field => `${field} = ?`).join(', ');
+        const values = fields.map(field => input[field]);
+        values.push(id);
+
+        await connection.query(`UPDATE admin SET ${setClause} WHERE id = UUID_TO_BIN(?)`, values);
+    }
+    static async deleteAdmin({ id }) {
+        const [result] = await connection.query('DELETE FROM admin WHERE id = UUID_TO_BIN(?)', [id]);
+        return result.affectedRows > 0;
+    }
+    static async getAdminById({ id }) {
+        const [rows] = await connection.query('SELECT BIN_TO_UUID(id) id, username, email, full_name FROM admin WHERE id = UUID_TO_BIN(?)', [id]);
+        return rows[0];
+    };
+
+    // Login del Admin
+    static async login({ username, password }) {
+        const [admins] = await connection.query(
+            'SELECT BIN_TO_UUID(id) id, username, password, email, full_name FROM admin WHERE username = ?',
+            [username]
+        );
+
+        if (admins.length === 0) {
+            throw new Error('Admin not found');
+        }
+
+        const admin = admins[0];
+        const isValid = await bcrypt.compare(password, admin.password);
+        if (!isValid) {
+            throw new Error('Invalid credentials');
+        }
+
+        const token = jwt.sign(
+            { id: admin.id, username: admin.username },
+            secretKey,
+            { expiresIn: '7d' }
+        );
+
+        return { token, admin: { username: admin.username, full_name: admin.full_name } };
+    }
+
+}

--- a/models/mysql/admin.js
+++ b/models/mysql/admin.js
@@ -18,8 +18,7 @@ console.log("Connected to MySQL database")
 
 export class AdminModel {
     static async getAllAdmins() {
-        const [rows] = await connection.query(`SELECT BIN_TO_UUID(id) id, username, email, full_name, password
-      FROM admin;`)
+        const [rows] = await connection.query(`SELECT BIN_TO_UUID(id) id, username, email, full_name FROM admin;`)
         return rows
     }
 
@@ -30,7 +29,6 @@ export class AdminModel {
             username,
             password,
         } = input;
-        // 1. Validar que el username no exista
         const [validUserName] = await connection.query(
             'SELECT * FROM admin WHERE userName = ?',
             [username]
@@ -57,7 +55,7 @@ export class AdminModel {
 
             return adminsResult[0];
         } catch (e) {
-            throw new Error('Error creating admin');
+            throw new Error('Error creating admin', e);
         }
     }
 

--- a/models/mysql/attribute.js
+++ b/models/mysql/attribute.js
@@ -1,11 +1,13 @@
 import mysql from "mysql2/promise";
+import dotenv from 'dotenv';
+dotenv.config();
 // MySQL connection configuration
-const config = {
-  host: "localhost",
-  user: "root",
-  password: "",
-  database: "usersdb"
-}
+const config= {
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+};
 
 const connection = await mysql.createConnection(config)
 console.log("Connected to MySQL database")
@@ -25,7 +27,7 @@ export class AttributeModel {
     try {
       const [user] = await connection.query('SELECT * FROM user WHERE id = UUID_TO_BIN(?)', [user_id]);
       if (user.length === 0) {
-        throw new Error('Usuario no encontrado');
+        throw new Error('Attribute not found');
       }
 
       for (const attr of attributes) {
@@ -54,7 +56,7 @@ export class AttributeModel {
     const attributes = input;
 
     if (attributes?.length === 0) {
-      throw new Error('No hay campos para actualizar');
+      throw new Error('No updatable fields found');
     }
     try {
       let result
@@ -67,9 +69,9 @@ export class AttributeModel {
 
 
       if (result.affectedRows === 0) {
-        console.warn('No se actualizó ningún registro. Verificar si el ID existe y si los valores realmente cambiaron.');
+        console.warn('Update failed: no matching record found or no changes detected');
       }
-      return { message: 'Atributos actualizados', result }
+      return { message: 'Attributes updated', result }
     } catch (e) {
       throw new Error('Error updating attribute', e);
 

--- a/models/mysql/user.js
+++ b/models/mysql/user.js
@@ -1,11 +1,13 @@
 import mysql from "mysql2/promise";
+import dotenv from 'dotenv';
+dotenv.config();
 // MySQL connection configuration
-const config = {
-  host: "localhost",
-  user: "root",
-  password: "",
-  database: "usersdb"
-}
+const config= {
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+};
 
 const connection = await mysql.createConnection(config)
 
@@ -132,7 +134,7 @@ export class UserModel {
     const fields = Object.keys(input).filter(field => allowedFields.includes(field));
 
     if (fields.length === 0) {
-      throw new Error('No hay campos válidos para actualizar');
+      throw new Error('Update failed: no matching record found or no changes detected');
     }
 
     const setClause = fields.map(field => `${field} = ?`).join(', ');
@@ -154,7 +156,7 @@ export class UserModel {
         [id]
       )
       if (result.affectedRows === 0) {
-        throw new Error('No se pudo eliminar: el usuario no existe');
+        throw new Error('Unable to delete: user not found');
       }
       return result.affectedRows > 0
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.14.1",
         "zod": "^3.24.4"
       },
@@ -529,6 +532,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -559,6 +576,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -700,6 +723,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -907,6 +949,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2316,6 +2367,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -2330,6 +2415,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -2372,11 +2478,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -2538,6 +2686,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "dev": "node --watch server.js",
     "start:mysql": "node --watch server-with-mysql.js",
     "start:local": "node --watch server-with-local.js",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -14,16 +15,22 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "cors": "^2.8.5",
-    "dotenv": "^16.5.0",
-    "express": "^5.1.0",
-    "mysql2": "^3.14.1",
-    "zod": "^3.24.4"
+    "bcrypt": "6.0.0",
+    "cookie-parser": "1.4.7",
+    "cors": "2.8.5",
+    "dotenv": "16.5.0",
+    "express": "5.1.0",
+    "jsonwebtoken": "9.0.2",
+    "mysql2": "3.14.1",
+    "zod": "3.24.4"
   },
   "devDependencies": {
-    "@eslint/js": "^9.26.0",
-    "eslint": "^9.26.0",
-    "eslint-plugin-react": "^7.37.5",
-    "globals": "^16.1.0"
+    "@eslint/js": "9.26.0",
+    "eslint": "9.26.0",
+    "eslint-plugin-react": "7.37.5",
+    "globals": "16.1.0"
+  },
+  "eslintConfig": {
+    "extends": "standard"
   }
 }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,0 +1,18 @@
+import { Router } from 'express'
+import { AdminController } from '../controllers/admin.js'
+
+export const createAdminRouter = ({ adminModel }) => {
+    const adminsRouter = Router()
+
+    const adminController = new AdminController({ adminModel })
+
+    adminsRouter.get('/', adminController.getAllAdmins)
+    adminsRouter.post('/', adminController.createAdmin)
+    adminsRouter.get('/:id', adminController.getAdminById)
+    adminsRouter.delete('/:id', adminController.deleteAdmin)
+    adminsRouter.patch('/:id', adminController.updateAdmin)
+    adminsRouter.post('/login', adminController.login)
+    adminsRouter.post('/logout', adminController.logout)
+
+    return adminsRouter
+}

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,12 +1,13 @@
 import { Router } from 'express'
 import { AdminController } from '../controllers/admin.js'
+import { cacheFor } from "../middlewares/apicache.js"
 
 export const createAdminRouter = ({ adminModel }) => {
     const adminsRouter = Router()
 
     const adminController = new AdminController({ adminModel })
 
-    adminsRouter.get('/', adminController.getAllAdmins)
+    adminsRouter.get('/', cacheFor(), adminController.getAllAdmins)
     adminsRouter.post('/', adminController.createAdmin)
     adminsRouter.get('/:id', adminController.getAdminById)
     adminsRouter.delete('/:id', adminController.deleteAdmin)

--- a/routes/attributes.js
+++ b/routes/attributes.js
@@ -9,7 +9,7 @@ export const createAttributeRouter = ({ attributeModel }) => {
   attributesRouter.post('/', attributeController.createAttribute)
   attributesRouter.get('/', attributeController.getAllAttributes)
   attributesRouter.delete('/:id', attributeController.deleteAttribute)
-  attributesRouter.patch('/:id', attributeController.updateAttribute)
+  attributesRouter.patch('/', attributeController.updateAttribute)
 
   return attributesRouter
 }

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,14 +1,15 @@
 import { Router } from 'express'
 import { UserController } from '../controllers/users.js'
+import { cacheFor } from "../middlewares/apicache.js"
 
 export const createUserRouter = ({ userModel }) => {
   const usersRouter = Router()
 
   const userController = new UserController({ userModel })
 
-  usersRouter.get('/', userController.getAllUsers)
+  usersRouter.get('/', cacheFor(), userController.getAllUsers)
   usersRouter.post('/', userController.createUser)
-  usersRouter.get('/:id', userController.getUserById)
+  usersRouter.get('/:id', cacheFor(), userController.getUserById)
   usersRouter.delete('/:id', userController.deleteUser)
   usersRouter.patch('/:id', userController.updateUser)
 

--- a/schemas/admin.js
+++ b/schemas/admin.js
@@ -1,0 +1,35 @@
+import z from 'zod'
+
+const adminSchema = z.object({
+  username: z.string({
+    invalid_type_error: 'username must be a string',
+    required_error: 'username is required.'
+  }),
+  email: z.string({
+    invalid_type_error: 'email must be a string',
+    required_error: 'email is required.'
+  }),
+  full_name: z.string({
+    invalid_type_error: 'full_name must be a string',
+    required_error: 'full_name is required.'
+  }),
+  password: z.string({
+    invalid_type_error: 'password must be a string',
+    required_error: 'password is required.'
+  }).min(8, { message: 'Password must be at least 8 characters long' }),
+})
+
+export function validateAdmin(input) {
+  return adminSchema.safeParse(input)
+}
+export function validatePartialAdmin(input) {
+  return adminSchema.partial().safeParse(input)
+}
+export const validateAdminLogin = (data) => {
+  const loginSchema = z.object({
+    username: z.string().min(3, 'Username is required'),
+    password: z.string().min(6, 'Password is required'),
+  });
+
+  return loginSchema.safeParse(data);
+};

--- a/schemas/attribute.js
+++ b/schemas/attribute.js
@@ -5,18 +5,49 @@ const attributeSchema = z.object({
     invalid_type_error: 'user_id must be a string',
     required_error: 'user_id is required.'
   }),
-  attributes: z.record(
-    z.string({
-      invalid_type_error: 'attribute_name must be a string',
-      required_error: 'attribute_name is required.'
+  attributes: z.array(
+    z.object({
+      id: z.string({
+        required_error: 'id is required',
+        invalid_type_error: 'id must be a string'
+      }).optional(),
+      name: z.string({
+        required_error: 'name is required',
+        invalid_type_error: 'name must be a string'
+      }),
+      value: z.string({
+        required_error: 'value is required',
+        invalid_type_error: 'value must be a string'
+      })
     }),
-    z.string({
-      invalid_type_error: 'attribute_value must be a string',
-      required_error: 'attribute_value is required.'
-    }) 
   )
 })
 
-export function validateAttribute (input) {
+const singleAttributeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  value: z.string()
+});
+
+const singleAttributeCreateSchema = z.object({
+  user_id: z.string({
+    invalid_type_error: 'user_id must be a string',
+    required_error: 'user_id is required.'
+  }),
+  attributes: z.object({
+    name: z.string(),
+    value: z.string()
+  })
+
+});
+
+export const validateAttributeArray = (input) => {
+  return z.array(singleAttributeSchema).safeParse(input);
+};
+
+export function validateAttribute(input) {
   return attributeSchema.safeParse(input)
+}
+export function validateSingleAttribute(input) {
+  return singleAttributeCreateSchema.safeParse(input)
 }

--- a/schemas/user.js
+++ b/schemas/user.js
@@ -16,11 +16,6 @@ const userSchema = z.object({
     required_error: 'user_id is required.'
   }),
   identification: z.number().int().positive(), // hay un minimo y maximo de numeros?
-  password: z.string({
-    invalid_type_error: 'password must be a string',
-    required_error: 'password is required.'
-  }).min(8, { message: 'Password must be at least 8 characters long' }),
-  attribute_name: z.string().optional() // optional attribute
 })
 
 export function validateUser (input) {

--- a/schemas/user.js
+++ b/schemas/user.js
@@ -10,11 +10,7 @@ const userSchema = z.object({
     invalid_type_error: 'full_name must be a string',
     required_error: 'full_name is required.'
   }),
-  state: z.string().default('activo'),
-  user_name: z.string({
-    invalid_type_error: 'user_id must be a string',
-    required_error: 'user_id is required.'
-  }),
+  state: z.string(),
   identification: z.number().int().positive(), // hay un minimo y maximo de numeros?
 })
 

--- a/schemas/user.js
+++ b/schemas/user.js
@@ -5,13 +5,13 @@ const userSchema = z.object({
     invalid_type_error: 'full_name must be a string',
     required_error: 'full_name is required.'
   }),
-  age: z.number().int(), // hay un rango de edad requerido?
+  age: z.number().int(), // Is there an age range required?
   gender: z.string({
     invalid_type_error: 'full_name must be a string',
     required_error: 'full_name is required.'
   }),
   state: z.string(),
-  identification: z.number().int().positive(), // hay un minimo y maximo de numeros?
+  identification: z.number().int().positive(), // Is there a minimum and maximum number of digits for the identification?
 })
 
 export function validateUser (input) {

--- a/server-with-mysql.js
+++ b/server-with-mysql.js
@@ -2,4 +2,5 @@ import { createApp } from './app.js'
 
 import { UserModel } from './models/mysql/user.js'
 import { AttributeModel } from './models/mysql/attribute.js'
-createApp({ userModel: UserModel, attributeModel: AttributeModel })
+import { AdminModel } from './models/mysql/admin.js'
+createApp({ userModel: UserModel, attributeModel: AttributeModel, adminModel: AdminModel })

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1,16 +1,21 @@
 DROP DATABASE IF EXISTS usersdb;
 CREATE DATABASE usersdb;
-DROP TABLE attribute;
 
 USE usersdb;
 
+-- Aseguramos que no queden residuos de tablas anteriores
+DROP TABLE IF EXISTS attribute;
+DROP TABLE IF EXISTS user;
+DROP TABLE IF EXISTS admin;
+
+-- Creamos las tablas
 CREATE TABLE user (
   id BINARY(16) PRIMARY KEY,
   full_name VARCHAR(255) NOT NULL,
   identification VARCHAR(255) NOT NULL UNIQUE,
   age INT,
   gender VARCHAR(100) NOT NULL,
-  state ENUM('Activo', 'Inactivo') NOT NULL
+  state ENUM('Active', 'Inactive') NOT NULL
 );
 
 CREATE TABLE attribute (
@@ -21,6 +26,7 @@ CREATE TABLE attribute (
   FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
   UNIQUE (user_id, attribute_name)
 );
+
 CREATE TABLE admin (
   id BINARY(16) PRIMARY KEY,
   username VARCHAR(50) NOT NULL UNIQUE,

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1,0 +1,31 @@
+DROP DATABASE IF EXISTS usersdb;
+CREATE DATABASE usersdb;
+DROP TABLE attribute;
+
+USE usersdb;
+
+CREATE TABLE user (
+  id BINARY(16) PRIMARY KEY,
+  full_name VARCHAR(255) NOT NULL,
+  identification VARCHAR(255) NOT NULL UNIQUE,
+  age INT,
+  gender VARCHAR(100) NOT NULL,
+  state ENUM('Activo', 'Inactivo') NOT NULL
+);
+
+CREATE TABLE attribute (
+  id BINARY(16) PRIMARY KEY DEFAULT (UUID_TO_BIN(UUID())),
+  user_id BINARY(16) NOT NULL,
+  attribute_name VARCHAR(255) NOT NULL,
+  attribute_value TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
+  UNIQUE (user_id, attribute_name)
+);
+CREATE TABLE admin (
+  id BINARY(16) PRIMARY KEY,
+  username VARCHAR(50) NOT NULL UNIQUE,
+  email VARCHAR(50) NOT NULL,
+  full_name VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
 1. CRUD para Admin
Create: Ruta para registrar nuevos administradores, incluyendo hash de la contraseña con bcrypt.

Read: Ruta para obtener todos los administradores (GET /admin).

Update: Ruta para modificar datos del admin (incluyendo que ahora al actualizar contraseña también se hashéa).

Delete: Ruta para eliminar un admin.

 2. Login con JWT
Implemente un login que:

Valida credenciales con bcrypt.compare().

Genera un token JWT con expiración.

Guarda el token en una cookie llamada access_token.

3. Validación con Zod
Use zod para:

Validar los datos de entrada cuando se crea o actualiza un admin (como username, email, password, etc.).

Evitar que se envíen campos inválidos desde el front o Postman.

 4. Autenticación con Middleware
Creamos un middleware llamado authenticateAdmin que:

Lee el token desde la cookie access_token.

Lo verifica usando jwt.verify().

Si es válido, agrega los datos del admin a req.session.admin.

Para proteger las rutas sensibles (como ver admins o eliminarlos).

 5. Implemente logout:
Limpia la cookie access_token.

Borra la sesión (req.session.admin = null).